### PR TITLE
Travis CIの設定ファイルを追加した

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,23 @@
+language: c
+
+os: linux
+
+dist: bionic
+
+compiler: clang
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+      - sourceline: deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-10 main
+        key_url: https://apt.llvm.org/llvm-snapshot.gpg.key
+    packages:
+      - llvm-10-dev
+      - libclang-10-dev
+      - libx11-dev
+      - libcairo2-dev
+      - libjson-c-dev
+
+script:
+  - make


### PR DESCRIPTION
- 自動テスト（CI）の[Travis CI](https://travis-ci.com)の設定ファイル`.travis.yml`を追加した
    - 手元でやった結果 👉 https://travis-ci.com/github/y-yu/miteWM/builds/186794835
- gccによるコンパイルも試したが、エラーとなった
    - https://travis-ci.com/github/y-yu/miteWM/jobs/391258363
    - この部分 👇 がエラーとなってコンパイルできない
        - https://github.com/Perukii/miteWM/blob/3484bbe50312d5d0cc86a988c6c0d5c64edb3302/src/mitewm.c#L66-L67
- `README.md`に`libjson`が必要なことも追記したほうがいいか 🤔 

### このPRをマージしたあとにやること

1. [Travis CI](https://travis-ci.com)にGitHubのOAuthでログインする
    - このとき[https://travis-ci.**com**](https://travis-ci.com)を使うこと。[https://travis-ci.**org**]()はもはや非推奨となっている
    - Travis CIにログインするとGitHubのOAuthトークンで自動的に連携される
2. このPRマージ後のコミットから自動テストが開始される

